### PR TITLE
apply Carpentries Incubator template

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,10 +3,12 @@
 #------------------------------------------------------------
 
 # Which carpentry is this ("swc", "dc", or "lc")?
-carpentry: "dc"
+carpentry: "incubator"
 
 # Overall title for pages.
 title: "Introduction to the Command Line for Metagenomics"
+
+life_cycle: "beta"
 
 # Contact.  This *must* include the protocol: if it's an email
 # address, it must look like "mailto:lessons@software-carpentry.org",


### PR DESCRIPTION
This adjusts the lesson styling to use the Incubator template via [the remote theme](https://github.com/carpentries/carpentries-theme), and sets the life cycle stage to "beta"