### PR TITLE
remove Data Carpentry Slack badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4285900.svg)](https://doi.org/10.5281/zenodo.4285900)
 
-[![Create a Slack Account with us](https://img.shields.io/badge/Create_Slack_Account-The_Carpentries-071159.svg)](https://swc-slack-invite.herokuapp.com/) 
-[![Slack Status](https://img.shields.io/badge/Slack_Channel-dc--genomics-E01563.svg)](https://swcarpentry.slack.com/messages/C9N1K7DCY) 
-
 # Introduction to the Command Line for Metagenomics
 
 An introduction lesson to the Unix shell for people working with metagenomics data. This lesson is part of the [Metagenomics Workshop](https://carpentries-incubator.github.io/metagenomics-workshop/).


### PR DESCRIPTION
This removes the Carpentries/Data Carpentry Slack badges from the repository `README.md`.